### PR TITLE
Updates for Scrivener 2.0 format changes

### DIFF
--- a/flashbake/plugins/scrivener.py
+++ b/flashbake/plugins/scrivener.py
@@ -1,4 +1,4 @@
- #    copyright 2009 Jay Penney
+#    copyright 2009 Jason Penney
 #
 #    This file is part of flashbake.
 #


### PR DESCRIPTION
The Scrivener 2.0 NaNoWriMo preview was released Monday, and the layout of the .scriv bundles changed, which broke the Scrivener word count.  Code should now detect new or old style bundles and do the right thing.  I've tested it across a handful of my projects (pre and post 2.0 conversion).
