### PR TITLE
Resolves noreply.org issue for Location.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ history.""",
         install_requires='''
             enum34 >=1.0.3
             feedparser >=4.1
+            requests >=2.23.0
             ''',
         entry_points={
                 'console_scripts': [ 'flashbake = flashbake.console:main',

--- a/src/flashbake/__init__.py
+++ b/src/flashbake/__init__.py
@@ -120,10 +120,10 @@ class ControlConfig:
                 if isinstance(plugin, flashbake.plugins.AbstractMessagePlugin):
                     logging.debug("Message Plugin: %s" % plugin_name)
                     # TODO add notion of dependency for ordering
-                    #if 'flashbake.plugins.location:Location' == plugin_name:
+                    # if 'flashbake.plugins.location:Location' == plugin_name:
                     #    self.msg_plugins.insert(0, plugin)
-                    else:
-                        self.msg_plugins.append(plugin)
+                else:
+                    self.msg_plugins.append(plugin)
                 if isinstance(plugin, flashbake.plugins.AbstractFilePlugin):
                     logging.debug("File Plugin: %s" % plugin_name)
                     self.file_plugins.append(plugin)

--- a/src/flashbake/__init__.py
+++ b/src/flashbake/__init__.py
@@ -122,7 +122,7 @@ class ControlConfig:
                     # TODO add notion of dependency for ordering
                     # if 'flashbake.plugins.location:Location' == plugin_name:
                     #    self.msg_plugins.insert(0, plugin)
-                else:
+                    # else:
                     self.msg_plugins.append(plugin)
                 if isinstance(plugin, flashbake.plugins.AbstractFilePlugin):
                     logging.debug("File Plugin: %s" % plugin_name)

--- a/src/flashbake/__init__.py
+++ b/src/flashbake/__init__.py
@@ -120,8 +120,8 @@ class ControlConfig:
                 if isinstance(plugin, flashbake.plugins.AbstractMessagePlugin):
                     logging.debug("Message Plugin: %s" % plugin_name)
                     # TODO add notion of dependency for ordering
-                    if 'flashbake.plugins.location:Location' == plugin_name:
-                        self.msg_plugins.insert(0, plugin)
+                    #if 'flashbake.plugins.location:Location' == plugin_name:
+                    #    self.msg_plugins.insert(0, plugin)
                     else:
                         self.msg_plugins.append(plugin)
                 if isinstance(plugin, flashbake.plugins.AbstractFilePlugin):

--- a/src/flashbake/plugins/location.py
+++ b/src/flashbake/plugins/location.py
@@ -26,6 +26,7 @@ import os.path
 import re
 import urllib
 import urllib2
+from requests import get
 
 
 
@@ -141,26 +142,10 @@ class Location(AbstractMessagePlugin):
         return text_value
 
     def __get_ip(self):
-        no_reply = 'http://www.noreply.org'
-        opener = urllib2.build_opener(urllib2.HTTPCookieProcessor())
+        ip_me = get('https://api.ipify.org').text 
 
         try:
-            # open the weather API page
-            ping_reply = opener.open(urllib2.Request(no_reply)).read()
-            hello_line = None
-            for line in ping_reply.split('\n'):
-                if line.find('Hello') > 0:
-                    hello_line = line.strip()
-                    break
-            if hello_line is None:
-                logging.error('Failed to parse Hello with public IP address.')
-                return None
-            logging.debug(hello_line)
-            m = re.search('([0-9]+\.){3}([0-9]+){1}', hello_line)
-            if m is None:
-                logging.error('Failed to parse Hello with public IP address.')
-                return None
-            ip_addr = m.group(0)
+            ip_addr = ip_me
             return ip_addr
         except HTTPError, e:
             logging.error('Failed with HTTP status code %d' % e.code)


### PR DESCRIPTION
This pull request solves two outstanding issues. 

First, it replaces the now defunct noreply.org with [IPify](https://www.ipify.org/) as suggested by @abhidg. Per IPIfy's code samples, this solution uses the Requests library, which has been added to setup.py.

I also commented out some code in \_\_init.py__ that looked like it was a place marker for future development. The problem was this code forced Location.py results to the top of the commit message. Expected behavior is that plugin results end up in the commit message in the order they're placed in the Flashbake config file. 

If the pull request is accepted then issues #33 and #35 should be closed.