### PR TITLE
Mastodon plugin

### DIFF
--- a/src/flashbake/context.py
+++ b/src/flashbake/context.py
@@ -19,6 +19,7 @@
 
 import os.path
 import random
+import logging
 
 
 
@@ -45,8 +46,8 @@ def buildmessagefile(config):
                 connectable = True
                 connected = connected or plugin_success
         if connectable and not connected:
-            message_file.write('All of the plugins that use the network failed.\n')
-            message_file.write('Your computer may not be connected to the network.')
+            logging.error('All of the plugins that use the network failed.\n')
+            logging.error('Your computer may not be connected to the network.')
     finally:
         message_file.close()
     return msg_filename

--- a/src/flashbake/plugins/mastodon.py
+++ b/src/flashbake/plugins/mastodon.py
@@ -1,0 +1,76 @@
+#    Copyright 2021 Ian Paul
+#    Copyright 2009 Thomas Gideon
+#
+#    This file is part of flashbake.
+#
+#    flashbake is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    flashbake is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with flashbake.  If not, see <http://www.gnu.org/licenses/>.
+
+'''A plugin that scrapes your mastodon profile for n public toots. '''
+
+from bs4 import BeautifulSoup 
+#from requests import get
+from urllib.request import urlopen
+import urllib.error
+import logging
+from flashbake.plugins import AbstractMessagePlugin
+
+class Mastodon(AbstractMessagePlugin):
+	def __init__(self, plugin_spec):
+		AbstractMessagePlugin.__init__(self, plugin_spec, True)
+		self.define_property('account_url', required=True)
+		self.define_property('limit', int, False, 3)
+
+	def addcontext(self, message_file, config):
+		""" Add the specified number of toots to the commit context. """
+		name_list = self.fetch_usernames()
+		toot_list = self.fetch_toots()
+		toot_print = 0
+		while toot_print != self.limit:
+			message_file.write(f'By {name_list.pop(0).strip()}: {toot_list.pop(0).strip()} \n')
+			toot_print += 1
+	
+	def fetch_soup(self):
+		""" grab the Mastdon user's profile page in HTML"""
+		try:
+			url = self.account_url
+			response = urlopen(url)
+			soup = BeautifulSoup(response.read(), 'html.parser')
+			return soup
+		except urllib.error.HTTPError as e:
+			logging.error(f'Failed with HTTP status code {e.code}')
+			return (None, {})
+		except urllib.error.URLError as e:
+			logging.error(f'Plugin, {self.__class__}, failed to connect with network.')
+			logging.debug('Network failure reason, {e.reason}.')
+			return (None, {})
+
+	def fetch_usernames(self):
+		""" grab the username/author for each toot """
+		name_soup = self.fetch_soup()
+		user_names = name_soup.find_all('span', class_= 'display-name__account')
+		name_list = [] 
+		for handle in user_names:
+			raw_text = handle.text
+			final = '@'.join(raw_text.split('@')[0:2])
+			name_list.append(final)
+		return name_list
+
+	def fetch_toots(self):
+		""" grab the actual toots """
+		toot_soup = self.fetch_soup()
+		toot = toot_soup.find_all('div', class_="status__content")
+		toot_list=[]
+		for i in toot:
+			toot_list.append(i.text)
+		return toot_list

--- a/src/flashbake/plugins/mastodon.py
+++ b/src/flashbake/plugins/mastodon.py
@@ -33,9 +33,13 @@ class Mastodon(AbstractMessagePlugin):
 
 	def addcontext(self, message_file, config):
 		""" Add the specified number of toots to the commit context. """
-		final_toots = self.make_dict()
-		for key in final_toots:
-			print (f'By {key.strip()} : {final_toots[key].strip()}')
+		name_list = self.fetch_usernames()
+		toot_list = self.fetch_toots()
+		toot_print = 0
+		while toot_print != self.limit:
+			message_file.write(f'By {name_list.pop(0).strip()}: {toot_list.pop(0).strip()} \n')
+			toot_print += 1
+
 
 	def fetch_soup(self):
 		""" Grab the Mastodon user's profile page in HTML"""
@@ -70,11 +74,3 @@ class Mastodon(AbstractMessagePlugin):
 		for i in toot:
 			toot_list.append(i.text)
 		return toot_list
-
-	def make_dict(self):
-		""" Combine the username and toot lists into a dictionary. Then create a second dictionary applying the user limit. """
-		name_list = self.fetch_usernames()
-		toot_list = self.fetch_toots()
-		res = {name_list[i]: toot_list[i] for i in range(len(name_list))}
-		final_toots = dict(itertools.islice(res.items(), self.limit))
-		return final_toots

--- a/src/flashbake/plugins/mastodon.py
+++ b/src/flashbake/plugins/mastodon.py
@@ -38,7 +38,7 @@ class Mastodon(AbstractMessagePlugin):
 			print (f'By {key.strip()} : {final_toots[key].strip()}')
 
 	def fetch_soup(self):
-		""" grab the Mastodon user's profile page in HTML"""
+		""" Grab the Mastodon user's profile page in HTML"""
 		try:
 			response = urlopen(self.url)
 			soup = BeautifulSoup(response.read(), 'html.parser')
@@ -52,7 +52,7 @@ class Mastodon(AbstractMessagePlugin):
 			return (None, {})
 
 	def fetch_usernames(self):
-		""" grab the username/author for each toot """
+		""" Grab the username/author for each toot and put them in a list."""
 		name_soup = self.fetch_soup()
 		user_names = name_soup.find_all('span', class_= 'display-name__account')
 		name_list = [] 
@@ -63,7 +63,7 @@ class Mastodon(AbstractMessagePlugin):
 		return name_list
 
 	def fetch_toots(self):
-		""" grab the actual toots """
+		""" Grab the actual toots and put them in a list."""
 		toot_soup = self.fetch_soup()
 		toot = toot_soup.find_all('div', class_="status__content")
 		toot_list=[]
@@ -72,7 +72,7 @@ class Mastodon(AbstractMessagePlugin):
 		return toot_list
 
 	def make_dict(self):
-		""" Take the usernames and toos and create a dictionary from them. Then apply the user limit. """
+		""" Combine the username and toot lists into a dictionary. Then create a second dictionary applying the user limit. """
 		name_list = self.fetch_usernames()
 		toot_list = self.fetch_toots()
 		res = {name_list[i]: toot_list[i] for i in range(len(name_list))}

--- a/src/flashbake/plugins/mastodon.py
+++ b/src/flashbake/plugins/mastodon.py
@@ -18,8 +18,7 @@
 
 '''A plugin that scrapes your mastodon profile for n public toots. '''
 
-from bs4 import BeautifulSoup 
-#from requests import get
+from bs4 import BeautifulSoup
 from urllib.request import urlopen
 import urllib.error
 import logging
@@ -28,7 +27,7 @@ from flashbake.plugins import AbstractMessagePlugin
 class Mastodon(AbstractMessagePlugin):
 	def __init__(self, plugin_spec):
 		AbstractMessagePlugin.__init__(self, plugin_spec, True)
-		self.define_property('account_url', required=True)
+		self.define_property('url', required=True)
 		self.define_property('limit', int, False, 3)
 
 	def addcontext(self, message_file, config):
@@ -43,8 +42,7 @@ class Mastodon(AbstractMessagePlugin):
 	def fetch_soup(self):
 		""" grab the Mastdon user's profile page in HTML"""
 		try:
-			url = self.account_url
-			response = urlopen(url)
+			response = urlopen(self.url)
 			soup = BeautifulSoup(response.read(), 'html.parser')
 			return soup
 		except urllib.error.HTTPError as e:

--- a/src/flashbake/plugins/mastodon.py
+++ b/src/flashbake/plugins/mastodon.py
@@ -40,7 +40,6 @@ class Mastodon(AbstractMessagePlugin):
 			message_file.write(f'By {name_list.pop(0).strip()}: {toot_list.pop(0).strip()} \n')
 			toot_print += 1
 
-
 	def fetch_soup(self):
 		""" Grab the Mastodon user's profile page in HTML"""
 		try:


### PR DESCRIPTION
Here is the first edition of the Mastodon Plugin. I was hoping to avoid using the while loop, but it's the best option while keeping things simple.

I also changed two lines in context.py to `logging.error` instead of `message_file.write`.  All connectable plugins except for Feed and Weather are sometimes triggering those error messages right now, which I didn't catch during the port to Python 3. This might actually be an issue from a PyPI install and not manual.

Changing to logging avoids those errors getting written into the commit message, but it still keeps them for the dry run and `-c` flag. 