### PR TITLE
custom commit message

### DIFF
--- a/src/flashbake/console.py
+++ b/src/flashbake/console.py
@@ -111,6 +111,25 @@ def main():
         _handle_bad_plugin(error)
         sys.exit(1)
 
+    if len(args) == 3:
+        try: 
+            quiet_period = int(args[1])
+        except:
+            parser.error(f'Quite minutes, "{args[1]}", must be a valid number.' )
+            sys.exit(1)
+    try:
+        (hot_files, control_config) = control.parse_control(project_dir, control_file, control_config, hot_files)
+        if options.message:
+            special_message = str(sys.argv[2])
+            message_file.write(special_message)
+            commit.commit(control_config, hot_files, quiet_period)
+    except (flashbake.git.VCError, flashbake.ConfigError) as error:
+        logging.error(f'Error: {str(error)}' )
+        sys.exit(1)
+    except PluginError as error:
+        _handle_bad_plugin(error)
+        sys.exit(1)
+
 
 def multiple_projects():
     parser = _build_multi_parser()
@@ -196,6 +215,9 @@ def _build_main_parser():
     parser.add_option('-c', '--context', dest='context_only',
             action='store_true', default=False,
             help='just generate and show the commit message, don\'t check for changes')
+    parser.add_option('-m', '--message', dest='message',
+             action='store_true', default=False, 
+             help='add a message to the commit')
     parser.add_option('-v', '--verbose', dest='verbose',
             action='store_true', default=False,
             help='include debug information in the output')

--- a/src/flashbake/console.py
+++ b/src/flashbake/console.py
@@ -120,7 +120,7 @@ def main():
     try:
         (hot_files, control_config) = control.parse_control(project_dir, control_file, control_config, hot_files)
         if options.message:
-            special_message = str(sys.argv[2])
+            special_message = str(sys.argv[1])
             message_file.write(special_message)
             commit.commit(control_config, hot_files, quiet_period)
     except (flashbake.git.VCError, flashbake.ConfigError) as error:

--- a/src/flashbake/console.py
+++ b/src/flashbake/console.py
@@ -99,6 +99,10 @@ def main():
             commit.purge(control_config, hot_files)
         else:
             commit.commit(control_config, hot_files, quiet_period)
+        if options.message:
+            special_message = str(sys.argv[1])
+            message_file.write(special_message)
+            commit.commit(control_config, hot_files, quiet_period)
         if (options.dryrun):
             logging.info('\n\n========================================')
             logging.info('!!! Running in dry run mode.         !!!')
@@ -110,26 +114,6 @@ def main():
     except PluginError as error:
         _handle_bad_plugin(error)
         sys.exit(1)
-
-    if len(args) == 3:
-        try: 
-            quiet_period = int(args[1])
-        except:
-            parser.error(f'Quite minutes, "{args[1]}", must be a valid number.' )
-            sys.exit(1)
-    try:
-        (hot_files, control_config) = control.parse_control(project_dir, control_file, control_config, hot_files)
-        if options.message:
-            special_message = str(sys.argv[1])
-            message_file.write(special_message)
-            commit.commit(control_config, hot_files, quiet_period)
-    except (flashbake.git.VCError, flashbake.ConfigError) as error:
-        logging.error(f'Error: {str(error)}' )
-        sys.exit(1)
-    except PluginError as error:
-        _handle_bad_plugin(error)
-        sys.exit(1)
-
 
 def multiple_projects():
     parser = _build_multi_parser()

--- a/src/flashbake/console.py
+++ b/src/flashbake/console.py
@@ -22,6 +22,7 @@
 
 from flashbake import commit, context, control
 from flashbake.plugins import PluginError, PLUGIN_ERRORS
+from flashbake.plugins import AbstractMessagePlugin
 from optparse import OptionParser
 from os.path import join, realpath
 import flashbake.git
@@ -80,11 +81,18 @@ def main():
 
     quiet_period = 0
     if len(args) == 2:
-        try:
-            quiet_period = int(args[1])
-        except:
-            parser.error(f'Quiet minutes, "{args[1]}", must be a valid number.' )
-            sys.exit(1)
+        if args[1].isdigit():
+            try:
+                quiet_period = int(args[1])
+            except:
+                parser.error(f'Quiet minutes, "{args[1]}", must be a valid number.' )
+                sys.exit(1)
+        else:
+            try:
+                special_message = str(args[1])
+            except:
+                parser.error(f'Messages, "{args[1]}", must be a string.')
+                sys.exit(1)
     try:
         (hot_files, control_config) = control.parse_control(project_dir, control_file, control_config, hot_files)
         control_config.context_only = options.context_only
@@ -100,8 +108,7 @@ def main():
         else:
             commit.commit(control_config, hot_files, quiet_period)
         if options.message:
-            special_message = str(sys.argv[1])
-            message_file.write(special_message)
+            context.message_file.write(special_message)
             commit.commit(control_config, hot_files, quiet_period)
         if (options.dryrun):
             logging.info('\n\n========================================')

--- a/src/flashbake/console.py
+++ b/src/flashbake/console.py
@@ -22,7 +22,6 @@
 
 from flashbake import commit, context, control
 from flashbake.plugins import PluginError, PLUGIN_ERRORS
-from flashbake.plugins import AbstractMessagePlugin
 from optparse import OptionParser
 from os.path import join, realpath
 import flashbake.git

--- a/src/flashbake/console.py
+++ b/src/flashbake/console.py
@@ -39,6 +39,8 @@ def main():
     ''' Entry point used by the setup.py installation script. '''
     # handle options and arguments
     parser = _build_main_parser()
+    global special_message
+    special_message = ""
 
     (options, args) = parser.parse_args()
 
@@ -106,9 +108,6 @@ def main():
         if options.purge:
             commit.purge(control_config, hot_files)
         else:
-            commit.commit(control_config, hot_files, quiet_period)
-        if options.message:
-            context.message_file.write(special_message)
             commit.commit(control_config, hot_files, quiet_period)
         if (options.dryrun):
             logging.info('\n\n========================================')
@@ -208,7 +207,7 @@ def _build_main_parser():
             help='just generate and show the commit message, don\'t check for changes')
     parser.add_option('-m', '--message', dest='message',
              action='store_true', default=False, 
-             help='add a message to the commit')
+             help='to use this switch add the following to your .flashbake config file: plugins:flashbake.plugins.default:Default')
     parser.add_option('-v', '--verbose', dest='verbose',
             action='store_true', default=False,
             help='include debug information in the output')

--- a/src/flashbake/plugins/default.py
+++ b/src/flashbake/plugins/default.py
@@ -18,8 +18,9 @@
 '''  default.py - Stock plugin to add in some statically configured text into a commit message.'''
 
 from flashbake.plugins import AbstractMessagePlugin
-import flashbake
+from flashbake import console
 
+PLUGIN_SPEC = 'flashbake.plugins.default:Default'
 
 class Default(AbstractMessagePlugin):
     def __init__(self, plugin_spec):
@@ -29,7 +30,8 @@ class Default(AbstractMessagePlugin):
     def addcontext(self, message_file, config):
         """ Add a static message to the commit context. """
 
-        if self.message is not None:
+        if console.special_message is not None:
+            self.message = console.special_message
             message_file.write(f'{self.message}\n' )
 
         return True


### PR DESCRIPTION
This is a draft pull request related to issue #6 . I'd like some input on this to make sure I'm on the right track with how this feature should work. The idea is that you would manually run flashbake like `flashbake -m "the plot thickens" /home/ian/documents/big_story`. Then the message "the plot thickens" would be added to the commit message. 

So far, I've put in the switch in console.py. The problem is that I have to somehow link the input from the command line to the AbstractMessagePlugin to get the message from the CLI to the temporary file that holds all the commit message stuff. Does that sound right, or am I on the wrong path? Also, any suggestions about how to connect the two? 

Granted, this would be easier to implement as a plugin, but that's a little clunky since you'd have to type a new message into the flashbake config file every time you wanted to add a message. It also runs the risk of including that message in every automated commit, which is not ideal since this should be a manual only feature IMO.