### PR TITLE
Repo info plugins

### DIFF
--- a/src/flashbake/plugins/fileowners.py
+++ b/src/flashbake/plugins/fileowners.py
@@ -16,9 +16,9 @@
 #    You should have received a copy of the GNU General Public License
 #    along with flashbake.  If not, see <http://www.gnu.org/licenses/>.
 
-''' This plugin was inspired by a suggestion from @xtaran on GitHub. ''' 
-''' It adds information to the commit message about file owners and groups, ''' 
-''' and last modified time stamps, for files in the project directory. '''
+''' This plugin was inspired by a suggestion from @xtaran on GitHub.  
+    It adds information to the commit message about file owners and groups,  
+    and last modified time stamps, for files in the project directory. '''
 
 from flashbake.plugins import AbstractMessagePlugin
 import subprocess
@@ -32,6 +32,9 @@ class FileOwners(AbstractMessagePlugin):
         #for each file in the specified directory. 
 
     def addcontext(self, message_file, config):
+        ''' If the owners variable is not set to a specified folder. Use the
+        current folder instead. If it can't be found write an error message to
+        the commit message. '''
         if self.owners == None:
             try:
                 self.owners = os.getcwd()
@@ -39,16 +42,18 @@ class FileOwners(AbstractMessagePlugin):
                 message_file.write('Couldn\'t find the specified directory. Please ensure the config uses an absolute path. \n')
                 return False
 
-        ''' Add owners and groups data for the files and folders '''
-        ''' in the current directory. '''
-        fields = self.__getowners(self.owners)
+        fields = self.getowners(self.owners)
         for i in range(len(fields)):
-            message_file.write("{0} {1} {2} {3} {4}\n".format(fields[i][2], 
-                fields[i][3], fields[i][5], fields[i][6], fields[i][7]))
+            message_file.write(f'{fields[i][2]} {fields[i][3]} {fields[i][5]} {fields[i][6]} {fields[i][7]}\n')
 
-    def __getowners(self, owners):
+    def getowners(self, owners):
+        ''' get a list of all the important files and directories in the
+        specified directory including infomation about who owns the file, 
+        its group, and the timestamp for the most recent changes. '''
         check = subprocess.run(["ls", "-lAt", "--time-style=long-iso", owners],
                 capture_output=True, text=True).stdout.strip("\n")
+        ''' turn each line of that output into a list, and contain all the
+        lists in a larger list. '''
         fields = []
         for line in check.splitlines()[1:]:
             x = line.split()

--- a/src/flashbake/plugins/fileowners.py
+++ b/src/flashbake/plugins/fileowners.py
@@ -16,28 +16,39 @@
 #    You should have received a copy of the GNU General Public License
 #    along with flashbake.  If not, see <http://www.gnu.org/licenses/>.
 
-''' This plugin was inspired by a suggestion from @xtaran on GitHub. It adds information to the commit message about file owners and groups, and last modified time stamps, for files in the project directory. '''
+''' This plugin was inspired by a suggestion from @xtaran on GitHub. ''' 
+''' It adds information to the commit message about file owners and groups, ''' 
+''' and last modified time stamps, for files in the project directory. '''
 
 from flashbake.plugins import AbstractMessagePlugin
 import subprocess
+import os
 
 class FileOwners(AbstractMessagePlugin):
     def __init__(self, plugin_spec):
         AbstractMessagePlugin.__init__(self, plugin_spec)
-        self.define_property('owners', required=False) # Adds owner, group, and last modified time stamp to the commit message for each file in the specified directory. 
+        self.define_property('owners', required=False) 
+        # Adds owner, group, and last modified time stamp to the commit message
+        #for each file in the specified directory. 
 
     def addcontext(self, message_file, config):
         if self.owners == None:
-            message_file.write('Couldn\'t find the specified directory. Please ensure the config uses an absolute path.')
-            return False
+            try:
+                self.owners = os.getcwd()
+            except:
+                message_file.write('Couldn\'t find the specified directory. Please ensure the config uses an absolute path. \n')
+                return False
 
-        ''' Add owners and groups data for the files and folders in the current directory. '''
+        ''' Add owners and groups data for the files and folders '''
+        ''' in the current directory. '''
         fields = self.__getowners(self.owners)
         for i in range(len(fields)):
-            message_file.write("{0} {1} {2} {3} {4}\n".format(fields[i][2], fields[i][3], fields[i][5], fields[i][6], fields[i][7]))
+            message_file.write("{0} {1} {2} {3} {4}\n".format(fields[i][2], 
+                fields[i][3], fields[i][5], fields[i][6], fields[i][7]))
 
     def __getowners(self, owners):
-        check = subprocess.run(["ls", "-lAt", "--time-style=long-iso", owners], capture_output=True, text=True).stdout.strip("\n")
+        check = subprocess.run(["ls", "-lAt", "--time-style=long-iso", owners],
+                capture_output=True, text=True).stdout.strip("\n")
         fields = []
         for line in check.splitlines()[1:]:
             x = line.split()

--- a/src/flashbake/plugins/fileowners.py
+++ b/src/flashbake/plugins/fileowners.py
@@ -18,7 +18,7 @@
 
 ''' This plugin was inspired by a suggestion from @xtaran on GitHub.  
     It adds information to the commit message about file owners and groups,  
-    and last modified time stamps, for files in the project directory. '''
+    and last modified time stamps for files in the project directory. '''
 
 from flashbake.plugins import AbstractMessagePlugin
 import subprocess

--- a/src/flashbake/plugins/fileowners.py
+++ b/src/flashbake/plugins/fileowners.py
@@ -1,0 +1,46 @@
+#    Copyright 2022 Ian Paul
+#    Copyright 2009 Thomas Gideon
+#
+#    This file is part of flashbake.
+#
+#    flashbake is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    flashbake is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with flashbake.  If not, see <http://www.gnu.org/licenses/>.
+
+''' This plugin was inspired by a suggestion from @xtaran on GitHub. It adds information to the commit message about file owners and groups, and last modified time stamps, for files in the project directory. '''
+
+from flashbake.plugins import AbstractMessagePlugin
+import subprocess
+
+class FileOwners(AbstractMessagePlugin):
+    def __init__(self, plugin_spec):
+        AbstractMessagePlugin.__init__(self, plugin_spec)
+        self.define_property('owners', required=False) # Adds owner, group, and last modified time stamp to the commit message for each file in the specified directory. 
+
+    def addcontext(self, message_file, config):
+        if self.owners == None:
+            message_file.write('Couldn\'t find the specified directory. Please ensure the config uses an absolute path.')
+            return False
+
+        ''' Add owners and groups data for the files and folders in the current directory. '''
+        fields = self.__getowners(self.owners)
+        for i in range(len(fields)):
+            message_file.write("{0} {1} {2} {3} {4}\n".format(fields[i][2], fields[i][3], fields[i][5], fields[i][6], fields[i][7]))
+
+    def __getowners(self, owners):
+        check = subprocess.run(["ls", "-lAt", "--time-style=long-iso", owners], capture_output=True, text=True).stdout.strip("\n")
+        fields = []
+        for line in check.splitlines()[1:]:
+            x = line.split()
+            fields.append(x)
+        return fields 
+

--- a/src/flashbake/plugins/ignored.py
+++ b/src/flashbake/plugins/ignored.py
@@ -1,0 +1,46 @@
+#    Copyright 2022 Ian Paul
+#    Copyright 2009 Thomas Gideon
+#
+#    This file is part of flashbake.
+#
+#    flashbake is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    flashbake is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with flashbake.  If not, see <http://www.gnu.org/licenses/>.
+
+''' This plugin was inspired by a suggestion from @xtaran on GitHub. It adds information to the commit message about files in the specified directory that are present and being ignored by git. '''
+
+from flashbake.plugins import AbstractMessagePlugin
+import subprocess
+
+class Ignored(AbstractMessagePlugin):
+    def __init__(self, plugin_spec):
+        AbstractMessagePlugin.__init__(self, plugin_spec, False)
+        self.define_property('ignored', required=False) 
+    def addcontext(self, message_file, config):
+
+        ''' Add a list of the git repository's ignored but present files. '''
+        if self.ignored == None:
+            message_file.write('Please specify the git directory containing ignored files.')
+        else:
+            t = self.addignored(self.ignored)
+            message_file.write(t)
+
+    def addignored(self, ignored):
+        ''' Use the git command to obtain the file names, turn it into a list, sort the list for only ignored files, return those files as a single string with each filename separated by a comma.'''
+        fldr=subprocess.run(["git", "-C", ignored, "status", "-s", "--ignored"], capture_output=True, text=True).stdout.strip("\n")
+        x = fldr.splitlines()
+        sub = "!"
+        g = ([s for s in x if sub in s])
+        i = [elem.replace(sub, '') for elem in g]
+        t = ", ".join(i)
+        return t
+

--- a/src/flashbake/plugins/ignored.py
+++ b/src/flashbake/plugins/ignored.py
@@ -39,7 +39,7 @@ class Ignored(AbstractMessagePlugin):
                 return False
         
         t = self.addignored(self.ignored)
-        message_file.write(t)
+        message_file.write(t + "\n")
 
     def addignored(self, ignored):
         ''' Use the git command to obtain the file names, turn it into a list,

--- a/src/flashbake/plugins/ignored.py
+++ b/src/flashbake/plugins/ignored.py
@@ -39,10 +39,10 @@ class Ignored(AbstractMessagePlugin):
                 return False
         
         t = self.addignored(self.ignored)
-        message_file.write(t + "\n")
+        message_file.write("Present files currently ignored by git:" + "\n" + t + "\n")
 
     def addignored(self, ignored):
-        ''' Use the git command to obtain the file names, turn it into a list,
+        ''' Use the git status command to obtain the file names, turn it into a list,
         sort the list for only ignored files, return those files as a 
         single string with each filename separated by a comma.'''
 

--- a/src/flashbake/plugins/ignored.py
+++ b/src/flashbake/plugins/ignored.py
@@ -16,10 +16,13 @@
 #    You should have received a copy of the GNU General Public License
 #    along with flashbake.  If not, see <http://www.gnu.org/licenses/>.
 
-''' This plugin was inspired by a suggestion from @xtaran on GitHub. It adds information to the commit message about files in the specified directory that are present and being ignored by git. '''
+''' This plugin was inspired by a suggestion from @xtaran on GitHub. 
+It adds information to the commit message about files in the specified 
+directory that are present and being ignored by git. '''
 
 from flashbake.plugins import AbstractMessagePlugin
 import subprocess
+import os
 
 class Ignored(AbstractMessagePlugin):
     def __init__(self, plugin_spec):
@@ -29,14 +32,22 @@ class Ignored(AbstractMessagePlugin):
 
         ''' Add a list of the git repository's ignored but present files. '''
         if self.ignored == None:
-            message_file.write('Please specify the git directory containing ignored files.')
-        else:
-            t = self.addignored(self.ignored)
-            message_file.write(t)
+            try:
+                self.ignored = os.getcwd()
+            except:
+                message_file.write('Please specify the git directory containing ignored files.')
+                return False
+        
+        t = self.addignored(self.ignored)
+        message_file.write(t)
 
     def addignored(self, ignored):
-        ''' Use the git command to obtain the file names, turn it into a list, sort the list for only ignored files, return those files as a single string with each filename separated by a comma.'''
-        fldr=subprocess.run(["git", "-C", ignored, "status", "-s", "--ignored"], capture_output=True, text=True).stdout.strip("\n")
+        ''' Use the git command to obtain the file names, turn it into a list,
+        sort the list for only ignored files, return those files as a 
+        single string with each filename separated by a comma.'''
+
+        fldr=subprocess.run(["git", "-C", ignored, "status", "-s", "--ignored"]
+                , capture_output=True, text=True).stdout.strip("\n")
         x = fldr.splitlines()
         sub = "!"
         g = ([s for s in x if sub in s])

--- a/src/flashbake/plugins/ignored.py
+++ b/src/flashbake/plugins/ignored.py
@@ -17,8 +17,8 @@
 #    along with flashbake.  If not, see <http://www.gnu.org/licenses/>.
 
 ''' This plugin was inspired by a suggestion from @xtaran on GitHub. 
-It adds information to the commit message about files in the specified 
-directory that are present and being ignored by git. '''
+    It adds information to the commit message about files in the specified 
+    directory that are present and being ignored by git. '''
 
 from flashbake.plugins import AbstractMessagePlugin
 import subprocess

--- a/src/flashbake/plugins/lastlog.py
+++ b/src/flashbake/plugins/lastlog.py
@@ -11,14 +11,17 @@ class LastLog(AbstractMessagePlugin):
         #res1 = [item for items in llog for item in items if target in item] 
         #for i in range(len(llog)):
         #matching = [s for s in llog if target in s]
-        x = []
-        for s in llog:
-            for i in s:
-                if target in i:
-                    x.append(s)
+         
+        #x = []
+        #for s in llog:
+        x = [s for s in llog for i in s if target in i] 
+            #for i in s:
+            #    if target in i:
+            #        x.append(s)
         print(x)
         for i in range(len(x)):
             message_file.write("{0} {1} {2} {3} {4} {5}\n".format(x[i][0], x[i][3], x[i][4], x[i][5], x[i][8], x[i][6]))
+    
     def checklog(self):
         last = subprocess.run(["lastlog"], capture_output=True,
                 text=True).stdout.strip("\n")

--- a/src/flashbake/plugins/lastlog.py
+++ b/src/flashbake/plugins/lastlog.py
@@ -1,0 +1,33 @@
+from flashbake.plugins import AbstractMessagePlugin
+import subprocess
+
+class LastLog(AbstractMessagePlugin):
+    def __init__(self, plugin_spec):
+        AbstractMessagePlugin.__init__(self, plugin_spec)
+
+    def addcontext(self, message_file, config):
+        llog = self.checklog()
+        target = ":" 
+        #res1 = [item for items in llog for item in items if target in item] 
+        #for i in range(len(llog)):
+        #matching = [s for s in llog if target in s]
+        x = []
+        for s in llog:
+            for i in s:
+                if target in i:
+                    x.append(s)
+        print(x)
+        for i in range(len(x)):
+            message_file.write("{0} {1} {2} {3} {4} {5}\n".format(x[i][0], x[i][3], x[i][4], x[i][5], x[i][8], x[i][6]))
+    def checklog(self):
+        last = subprocess.run(["lastlog"], capture_output=True,
+                text=True).stdout.strip("\n")
+        llog = []
+        #target = ":"
+        for line in last.splitlines()[1:]:
+            x = line.split()
+            llog.append(x)
+        return llog
+        
+        #res1 = [item for items in llog for item in items if target in item]
+        #return res1 

--- a/src/flashbake/plugins/lastlog.py
+++ b/src/flashbake/plugins/lastlog.py
@@ -43,12 +43,13 @@ class LastLog(AbstractMessagePlugin):
         ''' take the date in each list in variable x, and see if they are equal
         to or newer than the specified period. Then write the relevant log
         entries to the commit message. '''
+        message_file.write(f'Most recent lastlog entries: \n')
         for i in x:
             date_placement = [i[3], i[4], i[5], i[6], i[8]]
             y = ' '.join(date_placement)
             past24 = datetime.datetime.now() - datetime.timedelta(hours=self.period)
             if datetime.datetime.strptime(y, "%a %b %d %H:%M:%S %Y") >= past24:
-                message_file.write(f'Most recent lastlog entries: \n{i[0]} {i[3]} {i[4]} {i[5]} {i[6]} {i[8]}\n')
+                message_file.write(f'{i[0]} {i[3]} {i[4]} {i[5]} {i[6]} {i[8]}\n')
     def checklog(self):
         ''' Get the lastlog and turn each line of the log into a list. '''
         last = subprocess.run(["lastlog"], capture_output=True,

--- a/src/flashbake/plugins/lastlog.py
+++ b/src/flashbake/plugins/lastlog.py
@@ -5,6 +5,7 @@ import datetime
 class LastLog(AbstractMessagePlugin):
     def __init__(self, plugin_spec):
         AbstractMessagePlugin.__init__(self, plugin_spec)
+        self.define_property('interval', int, required=False)
 
     def addcontext(self, message_file, config):
         llog = self.checklog()
@@ -12,22 +13,16 @@ class LastLog(AbstractMessagePlugin):
         ''' loop through llog and store a list of lists that contain a
         colon to the variable x.'''
         x = [s for s in llog for i in s if target in i] 
-        
-        #for i in range(len(x)):
-        #    message_file.write("{0} {1} {2} {3} {4} {5}\n".format(x[i][0], x[i][3], x[i][4], x[i][5], x[i][8], x[i][6]))
-        #for i in x:
-        #    print(i[8]) 
+        if self.interval == None:
+            self.interval = 24
         for i in x:
             date_placement = [i[3], i[4], i[5], i[6], i[8]]
             y = ' '.join(date_placement)
-            #print(date_placement)
-            past24 = datetime.datetime.now() - datetime.timedelta(hours=24)
-            #if datetime.datetime(*date_placement[2:4]) <= past24:
-            #    print(i)
+            past24 = datetime.datetime.now() - datetime.timedelta(hours=self.interval)
             if datetime.datetime.strptime(y, "%a %b %d %H:%M:%S %Y") >= past24:
-            #    print(i)
                 message_file.write(f'Most recent lastlog entries: \n{i[0]} {i[3]} {i[4]} {i[5]} {i[6]} {i[8]}')
     def checklog(self):
+        ''' Get the lastlog and turn each line into a list of lists. '''
         last = subprocess.run(["lastlog"], capture_output=True,
                 text=True).stdout.strip("\n")
         llog = []

--- a/src/flashbake/plugins/lastlog.py
+++ b/src/flashbake/plugins/lastlog.py
@@ -1,3 +1,26 @@
+#    Copyright 2022 Ian Paul
+#    Copyright 2009 Thomas Gideon
+#
+#    This file is part of flashbake.
+#
+#    flashbake is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    flashbake is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with flashbake.  If not, see <http://www.gnu.org/licenses/>.
+
+''' This plugin was inspired by a suggestion from @xtaran on Github.
+    It adds information from the lastlog to the commit message. By default this
+    includes who logged in to the system in the past 24 hours. That period can
+    be modified to suit different needs.'''
+
 from flashbake.plugins import AbstractMessagePlugin
 import subprocess
 import datetime

--- a/src/flashbake/plugins/lastlog.py
+++ b/src/flashbake/plugins/lastlog.py
@@ -5,24 +5,29 @@ import datetime
 class LastLog(AbstractMessagePlugin):
     def __init__(self, plugin_spec):
         AbstractMessagePlugin.__init__(self, plugin_spec)
-        self.define_property('interval', int, required=False)
+        self.define_property('period', int, required=False)
 
     def addcontext(self, message_file, config):
         llog = self.checklog()
         target = ":"
-        ''' loop through llog and store a list of lists that contain a
-        colon to the variable x.'''
-        x = [s for s in llog for i in s if target in i] 
-        if self.interval == None:
-            self.interval = 24
+        ''' loop through the lists in the llog variable, and store in the 
+        x variable any of the lists that contain a colon.'''
+        x = [s for s in llog for i in s if target in i]
+        ''' set the period to check the last log to the last 24 hours
+        unless the period is set by the user. '''
+        if self.period == None:
+            self.period = 24
+        ''' take the date in each list in variable x, and see if they are equal
+        to or newer than the specified period. Then write the relevant log
+        entries to the commit message. '''
         for i in x:
             date_placement = [i[3], i[4], i[5], i[6], i[8]]
             y = ' '.join(date_placement)
-            past24 = datetime.datetime.now() - datetime.timedelta(hours=self.interval)
+            past24 = datetime.datetime.now() - datetime.timedelta(hours=self.period)
             if datetime.datetime.strptime(y, "%a %b %d %H:%M:%S %Y") >= past24:
-                message_file.write(f'Most recent lastlog entries: \n{i[0]} {i[3]} {i[4]} {i[5]} {i[6]} {i[8]}')
+                message_file.write(f'Most recent lastlog entries: \n{i[0]} {i[3]} {i[4]} {i[5]} {i[6]} {i[8]}\n')
     def checklog(self):
-        ''' Get the lastlog and turn each line into a list of lists. '''
+        ''' Get the lastlog and turn each line of the log into a list. '''
         last = subprocess.run(["lastlog"], capture_output=True,
                 text=True).stdout.strip("\n")
         llog = []

--- a/src/flashbake/plugins/lastlog.py
+++ b/src/flashbake/plugins/lastlog.py
@@ -1,5 +1,6 @@
 from flashbake.plugins import AbstractMessagePlugin
 import subprocess
+import datetime
 
 class LastLog(AbstractMessagePlugin):
     def __init__(self, plugin_spec):
@@ -12,9 +13,20 @@ class LastLog(AbstractMessagePlugin):
         colon to the variable x.'''
         x = [s for s in llog for i in s if target in i] 
         
-        for i in range(len(x)):
-            message_file.write("{0} {1} {2} {3} {4} {5}\n".format(x[i][0], x[i][3], x[i][4], x[i][5], x[i][8], x[i][6]))
-    
+        #for i in range(len(x)):
+        #    message_file.write("{0} {1} {2} {3} {4} {5}\n".format(x[i][0], x[i][3], x[i][4], x[i][5], x[i][8], x[i][6]))
+        #for i in x:
+        #    print(i[8]) 
+        for i in x:
+            date_placement = [i[3], i[4], i[5], i[6], i[8]]
+            y = ' '.join(date_placement)
+            #print(date_placement)
+            past24 = datetime.datetime.now() - datetime.timedelta(hours=24)
+            #if datetime.datetime(*date_placement[2:4]) <= past24:
+            #    print(i)
+            if datetime.datetime.strptime(y, "%a %b %d %H:%M:%S %Y") >= past24:
+            #    print(i)
+                message_file.write(f'Most recent lastlog entries: \n{i[0]} {i[3]} {i[4]} {i[5]} {i[6]} {i[8]}')
     def checklog(self):
         last = subprocess.run(["lastlog"], capture_output=True,
                 text=True).stdout.strip("\n")

--- a/src/flashbake/plugins/lastlog.py
+++ b/src/flashbake/plugins/lastlog.py
@@ -7,18 +7,11 @@ class LastLog(AbstractMessagePlugin):
 
     def addcontext(self, message_file, config):
         llog = self.checklog()
-        target = ":" 
-        #res1 = [item for items in llog for item in items if target in item] 
-        #for i in range(len(llog)):
-        #matching = [s for s in llog if target in s]
-         
-        #x = []
-        #for s in llog:
+        target = ":"
+        ''' loop through llog and store a list of lists that contain a
+        colon to the variable x.'''
         x = [s for s in llog for i in s if target in i] 
-            #for i in s:
-            #    if target in i:
-            #        x.append(s)
-        print(x)
+        
         for i in range(len(x)):
             message_file.write("{0} {1} {2} {3} {4} {5}\n".format(x[i][0], x[i][3], x[i][4], x[i][5], x[i][8], x[i][6]))
     
@@ -26,11 +19,8 @@ class LastLog(AbstractMessagePlugin):
         last = subprocess.run(["lastlog"], capture_output=True,
                 text=True).stdout.strip("\n")
         llog = []
-        #target = ":"
         for line in last.splitlines()[1:]:
             x = line.split()
             llog.append(x)
         return llog
         
-        #res1 = [item for items in llog for item in items if target in item]
-        #return res1 


### PR DESCRIPTION
This pull request closes issue #25 . It adds three new plugins that can report on the state of the current repository in the commit message. This includes reporting on file owners, groups, and most recent timestamps for files in a specified directory. 
There's also a plugin to show the files that are being ignored by git, and the third one reports on recent system logins as taken from `lastlog`. 

By default the lastlog plugin grabs logins from the past 24 hours, but there's an option to specify a longer or shorter period. To err on the side of caution, the plugin does not write IP addresses to the commit message , but it could easily be modified to do so by individual users. 

I will leave this up for a day or two before merging in case anyone wants to comment or ask for changes. 